### PR TITLE
Feature #7356

### DIFF
--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -1288,13 +1288,13 @@ class Tracking(CkanCommand):
                  SET running_total = (
                     SELECT sum(count)
                     FROM tracking_summary t2
-                    WHERE t1.url = t2.url
+                    WHERE split_part(t1.url,'/download/',1) = split_part(t2.url,'/download/',1)
                     AND t2.tracking_date <= t1.tracking_date
                  )
                  ,recent_views = (
                     SELECT sum(count)
                     FROM tracking_summary t2
-                    WHERE t1.url = t2.url
+                    WHERE split_part(t1.url,'/download/',1) = split_part(t2.url,'/download/',1)
                     AND t2.tracking_date <= t1.tracking_date AND t2.tracking_date >= t1.tracking_date - 14
                  )
                  WHERE t1.running_total = 0 AND tracking_type = 'resource';'''

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -191,6 +191,7 @@ class PackageSearchIndex(SearchIndex):
                 pkg_dict['id'])
         pkg_dict['views_total'] = tracking_summary['total']
         pkg_dict['views_recent'] = tracking_summary['recent']
+        pkg_dict['views_download'] = tracking_summary['download']
 
         resource_fields = [('name', 'res_name'),
                            ('description', 'res_description'),

--- a/ckan/model/tracking.py
+++ b/ckan/model/tracking.py
@@ -34,10 +34,10 @@ class TrackingSummary(domain_object.DomainObject):
         data = obj.order_by('tracking_date desc').first()
         if data:
             return {'total' : data.running_total,
-                    'recent': data.recent_views}
+                    'recent': data.recent_views,
+                    'download': cls.get_total_download(package_id)}
 
-        return {'total' : 0, 'recent' : 0}
-
+        return {'total' : 0, 'recent' : 0, 'download' : 0}
 
     @classmethod
     def get_for_resource(cls, url):
@@ -48,5 +48,12 @@ class TrackingSummary(domain_object.DomainObject):
                     'recent': data.recent_views}
 
         return {'total' : 0, 'recent' : 0}
+
+    @classmethod
+    def get_total_download(cls, package_id):
+        obj = meta.Session.query(cls).autoflush(False)
+        obj = obj.filter(cls.url.op('~')('dataset/%s/resource' % package_id))
+        data = sum([item.running_total for item in obj])
+        return data or 0
 
 meta.mapper(TrackingSummary, tracking_summary_table)


### PR DESCRIPTION
BC3 ID02 : Pouvoir conserver le nombre total de téléchargement d’une ressource, même si celle-ci a été renommée ou mise à jour avec un autre fichier. Cette valeur remplacera celle actuellement affichée dans la liste des ressources d’un dataset (dans CKAN), qui repart à zéro chaque fois que le fichier attaché à la ressource est modifié.